### PR TITLE
Fix: SEO component props

### DIFF
--- a/components/Shared/SEO.tsx
+++ b/components/Shared/SEO.tsx
@@ -1,9 +1,9 @@
 import Head from 'next/head'
 
 interface Props {
-  image: string
-  title: string
-  description: string
+  image?: string
+  title?: string
+  description?: string
 }
 
 export default function SEO({

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import MissionSection from '../components/Landing/MissionSection'
 import NewsletterSignup from '../components/Landing/NewsletterSignup'
 import StatsCard from '../components/Landing/StatsCard'
 import TestimonialCard from '../components/Landing/TestimonialCard'
-// import SEO from '../components/Shared/SEO'
+import SEO from '../components/Shared/SEO'
 import { getBlogPosts } from '../functions/api/blog'
 import { getCreators } from '../functions/api/creator'
 import { getLands } from '../functions/api/land'
@@ -27,7 +27,7 @@ export default function Home({
 }: Props): JSX.Element {
   return (
     <div>
-      {/* <SEO /> */}
+      <SEO />
       <Hero />
       <StatsCard creatorsNum={creatorsNum} itemsNum={758} landsNum={landsNum} />
       <TestimonialCard


### PR DESCRIPTION
Building with the SEO component currently fails with: `Type error: Type '{}' is missing the following properties from type 'Props': image, title, description`.

Making these props optional resolves #16.